### PR TITLE
Support 5 donation types

### DIFF
--- a/contracts/PixelDevsUkraineDonation.sol
+++ b/contracts/PixelDevsUkraineDonation.sol
@@ -16,7 +16,11 @@ contract PixelDevsUkraineDonation is ERC721Enumerable, ReentrancyGuard, Ownable 
 
     uint256 public minimumMintPrice = 12 ether;
 
-    event LogTokenMinted(address indexed minter, uint256 indexed tokenId);
+    enum DonationType{ BRONZE, SILVER, GOLD, DIAMOND, PLATINUM }
+
+    DonationType public donationType;
+
+    event LogTokenMinted(address indexed minter, uint256 indexed tokenId, string indexed donationType);
     event BaseURIUpdated(string indexed oldValue, string indexed newValue);
     event MinimumMintPriceUpdated(uint256 indexed oldValue, uint256 indexed newValue);
 
@@ -31,6 +35,21 @@ contract PixelDevsUkraineDonation is ERC721Enumerable, ReentrancyGuard, Ownable 
     function setBaseURI(string memory _newBaseURI) public onlyOwner {
         emit BaseURIUpdated(baseURI, _newBaseURI);
         baseURI = _newBaseURI;
+    }
+
+    function tokenURI(uint256 tokenID) public view override returns (string memory) {
+        if (donationType == DonationType.BRONZE) {
+            return string(bytes.concat(bytes(baseURI), bytes("bronze")));
+        } else if (donationType == DonationType.SILVER) {
+            return string(bytes.concat(bytes(baseURI), bytes("silver")));
+        } else if (donationType == DonationType.GOLD) {
+            return string(bytes.concat(bytes(baseURI), bytes("gold")));
+        } else if (donationType == DonationType.DIAMOND) {
+            return string(bytes.concat(bytes(baseURI), bytes("diamond")));
+        } else if (donationType == DonationType.PLATINUM) {
+            return string(bytes.concat(bytes(baseURI), bytes("platinum")));
+        }
+        return Strings.toString(tokenID);
     }
 
     function setMinimumMintPrice(uint256 _newPrice) public onlyOwner {
@@ -48,7 +67,23 @@ contract PixelDevsUkraineDonation is ERC721Enumerable, ReentrancyGuard, Ownable 
     {
         require(minimumMintPrice <= msg.value, "Not enough MATIC sent");
         _safeMint(msg.sender, tokenId);
-        emit LogTokenMinted(msg.sender, tokenId);
+
+        if (msg.value <= 25 ether) {
+            donationType = DonationType.BRONZE;
+            emit LogTokenMinted(msg.sender, tokenId, "bronze");
+        } else if (msg.value <= 50 ether) {
+            donationType = DonationType.SILVER;
+            emit LogTokenMinted(msg.sender, tokenId, "silver");
+        } else if (msg.value <= 100 ether) {
+            donationType = DonationType.GOLD;
+            emit LogTokenMinted(msg.sender, tokenId, "gold");
+        } else if (msg.value <= 500 ether) {
+            donationType = DonationType.DIAMOND;
+            emit LogTokenMinted(msg.sender, tokenId, "diamond");
+        } else {
+            donationType = DonationType.PLATINUM;
+            emit LogTokenMinted(msg.sender, tokenId, "platinum");
+        }
     }
 
     function withdraw() public onlyOwner {

--- a/test/PixelDevsUkraineDonation.test.js
+++ b/test/PixelDevsUkraineDonation.test.js
@@ -48,7 +48,7 @@ describe("PixelDevsUkraineDonation", function() {
         })
       )
         .to.emit(this.contract, "LogTokenMinted")
-        .withArgs(this.owner.address, 1234);
+        .withArgs(this.owner.address, 1234, "bronze");
 
       await expect(await this.contract.ownerOf(1234)).to.equal(
         this.owner.address
@@ -59,6 +59,76 @@ describe("PixelDevsUkraineDonation", function() {
       await expect(
         this.contract.mint(1111, { value: ethers.utils.parseEther("1") })
       ).to.be.revertedWith("Not enough MATIC sent");
+    });
+
+    it("should have donationType == BRONZE", async function() {
+      await expect(
+        this.contract.mint(1234, {
+          value: ethers.utils.parseEther("25"),
+        })
+      )
+        .to.emit(this.contract, "LogTokenMinted")
+        .withArgs(this.owner.address, 1234, "bronze");
+
+      await expect(await this.contract.tokenURI(1234)).to.equal(
+        "ipfs://abcd.../bronze"
+      );
+    });
+
+    it("should have donationType == SILVER", async function() {
+      await expect(
+        this.contract.mint(1234, {
+          value: ethers.utils.parseEther("50"),
+        })
+      )
+        .to.emit(this.contract, "LogTokenMinted")
+        .withArgs(this.owner.address, 1234, "silver");
+
+      await expect(await this.contract.tokenURI(1234)).to.equal(
+        "ipfs://abcd.../silver"
+      );
+    });
+
+    it("should have donationType == GOLD", async function() {
+      await expect(
+        this.contract.mint(1234, {
+          value: ethers.utils.parseEther("100"),
+        })
+      )
+        .to.emit(this.contract, "LogTokenMinted")
+        .withArgs(this.owner.address, 1234, "gold");
+
+      await expect(await this.contract.tokenURI(1234)).to.equal(
+        "ipfs://abcd.../gold"
+      );
+    });
+
+    it("should have donationType == DIAMOND", async function() {
+      await expect(
+        this.contract.mint(1234, {
+          value: ethers.utils.parseEther("500"),
+        })
+      )
+        .to.emit(this.contract, "LogTokenMinted")
+        .withArgs(this.owner.address, 1234, "diamond");
+
+      await expect(await this.contract.tokenURI(1234)).to.equal(
+        "ipfs://abcd.../diamond"
+      );
+    });
+
+    it("should have donationType == PLATINUM", async function() {
+      await expect(
+        this.contract.mint(1234, {
+          value: ethers.utils.parseEther("1000"),
+        })
+      )
+        .to.emit(this.contract, "LogTokenMinted")
+        .withArgs(this.owner.address, 1234, "platinum");
+
+      await expect(await this.contract.tokenURI(1234)).to.equal(
+        "ipfs://abcd.../platinum"
+      );
     });
   });
 


### PR DESCRIPTION
Add tokenURI() to support donation levels and their five unique metadata URIs.

Set donation level when token minted.

Add tests.